### PR TITLE
feat: support extra bundler options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revopush/code-push-cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revopush/code-push-cli",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "backslash": "^0.2.0",
         "chalk": "^4.1.2",

--- a/script/command-executor.ts
+++ b/script/command-executor.ts
@@ -1340,7 +1340,8 @@ export const releaseReact = (command: cli.IReleaseReactCommand): Promise<void> =
           entryFile,
           outputFolder,
           platform,
-          command.sourcemapOutput
+          command.sourcemapOutput,
+          command.extraBundlerOptions
         )
       )
       .then(async () => {
@@ -1431,7 +1432,8 @@ export const runReactNativeBundleCommand = (
   entryFile: string,
   outputFolder: string,
   platform: string,
-  sourcemapOutput: string
+  sourcemapOutput: string,
+  extraBundlerOptions: string[]
 ): Promise<void> => {
   const reactNativeBundleArgs: string[] = [];
   const envNodeArgs: string = process.env.CODE_PUSH_NODE_ARGS;
@@ -1459,6 +1461,10 @@ export const runReactNativeBundleCommand = (
 
   if (sourcemapOutput) {
     reactNativeBundleArgs.push("--sourcemap-output", sourcemapOutput);
+  }
+
+  if (extraBundlerOptions.length > 0) {
+    reactNativeBundleArgs.push(...extraBundlerOptions);
   }
 
   log(chalk.cyan('Running "react-native bundle" command:\n'));

--- a/script/command-parser.ts
+++ b/script/command-parser.ts
@@ -840,6 +840,14 @@ yargs
           "Name of build configuration which specifies the binary version you want to target this release at. For example, 'Debug' or 'Release' (iOS only)",
         type: "string",
       })
+      .option("extraBundlerOption", {
+        alias: "eo",
+        default: [],
+        demand: false,
+        description:
+          "Option that gets passed to react-native bundler. Can be specified multiple times.",
+        type: "array",
+      })
       .check((argv: any, aliases: { [aliases: string]: string }): any => {
         return checkValidReleaseOptions(argv);
       });
@@ -1245,6 +1253,7 @@ export function createCommand(): cli.ICommand {
           releaseReactCommand.xcodeProjectFile = argv["xcodeProjectFile"] as any;
           releaseReactCommand.xcodeTargetName = argv["xcodeTargetName"] as any;
           releaseReactCommand.buildConfigurationName = argv["buildConfigurationName"] as any;
+          releaseReactCommand.extraBundlerOptions = argv["extraBundlerOption"] as any;
         }
         break;
 

--- a/script/types/cli.ts
+++ b/script/types/cli.ts
@@ -206,6 +206,7 @@ export interface IReleaseReactCommand extends IReleaseBaseCommand {
   xcodeProjectFile?: string;
   xcodeTargetName?: string;
   buildConfigurationName?: string;
+  extraBundlerOptions?: string[];
 }
 
 export interface IRollbackCommand extends ICommand {

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -1595,6 +1595,50 @@ describe("CLI", () => {
       .done();
   });
 
+  it("release-react applies extraBundlerOptions to bundler command", (done: Mocha.Done): void => {
+    var bundleName = "bundle.js";
+    var command: cli.IReleaseReactCommand = {
+      type: cli.CommandType.releaseReact,
+      appName: "a",
+      appStoreVersion: null,
+      bundleName: bundleName,
+      deploymentName: "Staging",
+      description: "Test default entry file",
+      mandatory: false,
+      rollout: null,
+      platform: "ios",
+      extraBundlerOptions: ["--foo=bar", "--baz"],
+    };
+
+    ensureInTestAppDirectory();
+
+    var release: sinon.SinonSpy = sandbox.stub(cmdexec, "release");
+
+    cmdexec
+      .execute(command)
+      .then(() => {
+        var releaseCommand: cli.IReleaseCommand = <any>command;
+        releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+        releaseCommand.appStoreVersion = "1.2.3";
+
+        sinon.assert.calledOnce(spawn);
+        var spawnCommand: string = spawn.args[0][0];
+        var spawnCommandArgs: string = spawn.args[0][1].join(" ");
+        assert.equal(spawnCommand, "node");
+        assert.equal(
+          spawnCommandArgs,
+          `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(
+            os.tmpdir(),
+            "CodePush"
+          )} --bundle-output ${path.join(os.tmpdir(), "CodePush", bundleName)} --dev false --entry-file index.ios.js --platform ios --foo=bar --baz`
+        );
+        assertJsonDescribesObject(JSON.stringify(release.args[0][0], /*replacer=*/ null, /*spacing=*/ 2), releaseCommand);
+
+        done();
+      })
+      .done();
+  });
+
   it("sessionList lists session name and expires fields", (done: Mocha.Done): void => {
     var command: cli.IAccessKeyListCommand = {
       type: cli.CommandType.sessionList,


### PR DESCRIPTION
Adds support for the `extraBundlerOption` flag, aligning with the implementation from the AppCenter CLI.

Fixes [!5](https://github.com/revopush/code-push-cli/issues/5)

Reference: https://github.com/microsoft/appcenter-cli/blob/7e0ac3ed45de8727a716d062b8633b55065be013/src/commands/codepush/release-react.ts#L115C3-L115C36