### PR TITLE
fix hermes path in case of single platform only

### DIFF
--- a/script/react-native-utils.ts
+++ b/script/react-native-utils.ts
@@ -245,11 +245,10 @@ export async function getMinifyParams(command: cli.IReleaseReactCommand) {
 }
 
 export async function isHermesEnabled(command: cli.IReleaseReactCommand, platform: string = command.platform.toLowerCase()) {
-  // Check if we have to run hermes to compile JS to Byte Code if Hermes is enabled in Podfile and we're releasing an iOS build
-  const isAndroidHermesEnabled = await getAndroidHermesEnabled(command.gradleFile);
-  const isIOSHermesEnabled = getiOSHermesEnabled(command.podFile);
-
-  return command.useHermes || (platform === "android" && isAndroidHermesEnabled) || (platform === "ios" && isIOSHermesEnabled);
+  if (command.useHermes) return true;
+  if (platform === "android") return getAndroidHermesEnabled(command.gradleFile);
+  if (platform === "ios") return getiOSHermesEnabled(command.podFile);
+  return false;
 }
 
 function parseBuildGradleFile(gradleFile: string) {
@@ -257,11 +256,13 @@ function parseBuildGradleFile(gradleFile: string) {
   if (gradleFile) {
     buildGradlePath = gradleFile;
   }
-  if (fs.lstatSync(buildGradlePath).isDirectory()) {
-    buildGradlePath = path.join(buildGradlePath, "build.gradle");
-  }
 
-  if (fileDoesNotExistOrIsDirectory(buildGradlePath)) {
+  try {
+    if (fs.lstatSync(buildGradlePath).isDirectory()) {
+      buildGradlePath = path.join(buildGradlePath, "build.gradle");
+      fs.accessSync(buildGradlePath);
+    }
+  } catch {
     throw new Error(`Unable to find gradle file "${buildGradlePath}".`);
   }
 
@@ -345,12 +346,13 @@ async function getAndroidHermesEnabled(gradleFile: string): Promise<boolean> {
 }
 
 function getiOSHermesEnabled(podFile: string): boolean {
-  let podPath = path.join("ios", "Podfile");
-  if (podFile) {
-    podPath = podFile;
-  }
-  if (fileDoesNotExistOrIsDirectory(podPath)) {
+  const podPath = podFile || path.join("ios", "Podfile");
+  if (podFile && fileDoesNotExistOrIsDirectory(podPath)) {
     throw new Error(`Unable to find Podfile file "${podPath}".`);
+  } else if (!podFile && fileDoesNotExistOrIsDirectory(podPath)) {
+    // No Podfile at default path (e.g. Android-only project); fall back to RN version heuristic
+    const rnVersion = coerce(getReactNativeVersion())?.version;
+    return !!(rnVersion && compare(rnVersion, "0.70.0") >= 0);
   }
 
   try {
@@ -422,7 +424,12 @@ async function getHermesCommand(gradleFile: string): Promise<string> {
     return bundledHermesEngine;
   }
 
-  const gradleHermesCommand = await getHermesCommandFromGradle(gradleFile);
+  let gradleHermesCommand = "";
+  try {
+    gradleHermesCommand = await getHermesCommandFromGradle(gradleFile);
+  } catch {
+    // Gradle files not present (e.g. iOS-only project); skip to node_modules fallback
+  }
   if (gradleHermesCommand) {
     return path.join("android", "app", gradleHermesCommand.replace("%OS-BIN%", getHermesOSBin()));
   } else {


### PR DESCRIPTION
                                                                                                                     
  Fix: Hermes detection for iOS-only and Android-only projects
                                                                                                                               
  Fixes #23                                                                                                                    
                          
  **Problem**                                                                                                                      
                                                                                   
  release-react fails with [Error] Unable to find gradle file "android/app" when run on an iOS-only project that has no        
  android/ directory. The inverse problem also exists: an Android-only project fails because ios/Podfile is not found.
                                                                                                                               
  The root cause was that Hermes detection and Hermes binary resolution unconditionally attempted to read both platform's      
  config files, regardless of the target platform.
                                                                                                                               
  Changes (script/react-native-utils.ts)                                                                                       
   
  `isHermesEnabled()` — now only invokes the check for the relevant platform. Previously it called both getAndroidHermesEnabled()
   and getiOSHermesEnabled() on every invocation, causing an unnecessary cross-platform file read that could fail.

  `getiOSHermesEnabled()` — when ios/Podfile is not found at its default path (no --podFile flag provided), falls back to the    
  React Native version heuristic (Hermes is the default engine since RN 0.70.0) instead of throwing. If the user explicitly
  passed --podFile some/path and that file does not exist, the original clear error is still raised.                           
                                                                                                                               
  `getHermesCommand()` — wraps the getHermesCommandFromGradle() call in a try/catch so that missing gradle files (e.g. iOS-only
  project) are silently skipped and resolution continues to the node_modules fallback chain.                                   
                                                                                   
  `parseBuildGradleFile()` — wraps fs.lstatSync() in a try/catch so a completely missing android/ directory produces the existing
   user-friendly error message instead of a raw ENOENT from Node.