### PR TITLE
Koltin version parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revopush/code-push-cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revopush/code-push-cli",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "@devicefarmer/adbkit-apkreader": "^3.2.4",
         "aab-parser": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revopush/code-push-cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revopush/code-push-cli",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@devicefarmer/adbkit-apkreader": "^3.2.4",
         "aab-parser": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revopush/code-push-cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Management CLI for the CodePush service",
   "main": "./script/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revopush/code-push-cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Management CLI for the CodePush service",
   "main": "./script/cli.js",
   "scripts": {

--- a/script/command-executor.ts
+++ b/script/command-executor.ts
@@ -41,14 +41,13 @@ import {
   takeHermesBaseBytecode,
 } from "./react-native-utils";
 import { fileDoesNotExistOrIsDirectory, fileExists, isBinaryOrZip, extractIPA, extractAPK, extractAAB } from "./utils/file-utils";
+import { getAndroidVersionInfo } from "./utils/gradle-utils";
 
 import AccountManager = require("./management-sdk");
 import wordwrap = require("wordwrap");
 import Promise = Q.Promise;
 import { ReactNativePackageInfo } from "./types/rest-definitions";
 import { getExpoCliPath } from "./expo-utils";
-
-const g2js = require("gradle-to-js/lib/parser");
 
 const opener = require("opener");
 
@@ -65,8 +64,6 @@ const xcode = require("xcode");
 const configFilePath: string = path.join(process.env.LOCALAPPDATA || process.env.HOME, ".revopush.config");
 const emailValidator = require("email-validator");
 const packageJson = require("../../package.json");
-
-const properties = require("properties");
 
 const CLI_HEADERS: Headers = {
   "X-CodePush-CLI-Version": packageJson.version,
@@ -940,114 +937,7 @@ function getReactNativeProjectVersionInfo(command: cli.IReleaseReactCommand, pro
 
     return Q({ appVersion: rawShortVersion, buildNumber: rawBundleVersion });
   } else if (command.platform === "android") {
-    let buildGradlePath: string = path.join("android", "app");
-    if (command.gradleFile) {
-      buildGradlePath = command.gradleFile;
-    }
-    if (fs.lstatSync(buildGradlePath).isDirectory()) {
-      buildGradlePath = path.join(buildGradlePath, "build.gradle");
-    }
-
-    if (fileDoesNotExistOrIsDirectory(buildGradlePath)) {
-      throw new Error(`Unable to find gradle file "${buildGradlePath}".`);
-    }
-
-    return g2js
-      .parseFile(buildGradlePath)
-      .catch(() => {
-        throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
-      })
-      .then((buildGradle: any) => {
-        const warnMissingBuildNumber = () => log(chalk.yellow(
-          `Warning: Unable to read "android.defaultConfig.versionCode" from "${buildGradlePath}". ` +
-            `This is expected if it is set dynamically (e.g. on CI). ` +
-            `Pass --buildNumber explicitly to include it in the release.`
-        ));
-
-        const knownLocations = [path.join("android", "app", "gradle.properties"), path.join("android", "gradle.properties")];
-
-        const parsePropertiesFile = (filePath: string): any | null => {
-          if (!fileExists(filePath)) return null;
-          try {
-            return properties.parse(fs.readFileSync(filePath).toString());
-          } catch (e) {
-            throw new Error(`Unable to parse "${filePath}". Please ensure it is a well-formed properties file.`);
-          }
-        };
-
-        let versionName: string | null = null;
-        let versionCode: string | number | null = null;
-
-        // First 'if' statement was implemented as workaround for case
-        // when 'build.gradle' file contains several 'android' nodes.
-        // In this case 'buildGradle.android' prop represents array instead of object
-        // due to parsing issue in 'g2js.parseFile' method.
-        if (buildGradle.android instanceof Array) {
-          for (const gradlePart of buildGradle.android) {
-            if (gradlePart.defaultConfig) {
-              versionName = versionName ?? gradlePart.defaultConfig.versionName ?? null;
-              versionCode = versionCode ?? gradlePart.defaultConfig.versionCode ?? null;
-              if (versionName !== null && versionCode !== null) break;
-            }
-          }
-        } else if (buildGradle.android && buildGradle.android.defaultConfig) {
-          versionName = buildGradle.android.defaultConfig.versionName ?? null;
-          versionCode = buildGradle.android.defaultConfig.versionCode ?? null;
-        }
-
-        // versionCode may be a direct value or a property reference (non-numeric string)
-        const versionCodeProperty = typeof versionCode === "string" && !/^\d+$/.test(versionCode)
-          ? versionCode.replace("project.", "")
-          : null;
-        let buildNumber: string | undefined = versionCodeProperty ? undefined : versionCode?.toString();
-
-        if (!versionName) {
-          if (!buildNumber) warnMissingBuildNumber();
-          return { appVersion: undefined, buildNumber };
-        }
-
-        const rawAppVersion = versionName.replace(/"/g, "").trim();
-
-        if (/^\d/.test(rawAppVersion) && !isValidVersion(rawAppVersion)) {
-          // Starts with a digit but isn't valid semver — can't be a property reference.
-          throw new Error(
-            `The "android.defaultConfig.versionName" property in the "${buildGradlePath}" file needs to specify a valid semver string (e.g. 1.3.2).`
-          );
-        }
-
-        // If versionName isn't a valid semver, treat it as a Gradle property reference
-        const versionNameProperty: string | null = isValidVersion(rawAppVersion) ? null : rawAppVersion.replace("project.", "");
-        let appVersion: string | undefined = versionNameProperty ? undefined : rawAppVersion;
-
-        let resolvedPropertiesFile: string | null = null;
-        if (versionNameProperty || versionCodeProperty) {
-          for (const propertiesFile of knownLocations) {
-            const parsed = parsePropertiesFile(propertiesFile);
-            if (!parsed) continue;
-            if (versionNameProperty && !appVersion) {
-              appVersion = parsed[versionNameProperty];
-              if (appVersion) resolvedPropertiesFile = propertiesFile;
-            }
-            if (versionCodeProperty && !buildNumber) {
-              buildNumber = parsed[versionCodeProperty];
-            }
-            if ((!versionNameProperty || appVersion) && (!versionCodeProperty || buildNumber)) break;
-          }
-
-          if (versionNameProperty && !appVersion) {
-            throw new Error(`No property named "${versionNameProperty}" exists in the following files: ${knownLocations.join(", ")}.`);
-          }
-          if (versionNameProperty && !isValidVersion(appVersion)) {
-            throw new Error(
-              `The "${versionNameProperty}" property in the "${resolvedPropertiesFile}" file needs to specify a valid semver string, containing both a major and minor version (e.g. 1.3.2, 1.1).`
-            );
-          }
-        }
-
-        if (!buildNumber) warnMissingBuildNumber();
-
-        return { appVersion, buildNumber };
-      });
+    return Q(getAndroidVersionInfo(command.gradleFile));
   }
 }
 
@@ -1381,10 +1271,10 @@ export const releaseExpo = (command: cli.IReleaseReactCommand): Promise<void> =>
       // For release-expo, buildNumber is NOT auto-detected — it must be passed explicitly
       // via --buildNumber. Auto-detection only applies to release-native where the binary
       // build number is the natural targeting key.
-      const versionInfoPromise: Promise<ProjectVersionInfo> = (command.appStoreVersion && command.buildNumber)
+      const versionInfoPromise: Promise<ProjectVersionInfo> = command.appStoreVersion
         ? Q({ appVersion: command.appStoreVersion, buildNumber: command.buildNumber })
         : getReactNativeProjectVersionInfo(command, projectName).then((detected) => ({
-            appVersion: command.appStoreVersion || detected.appVersion,
+            appVersion: detected.appVersion,
             buildNumber: command.buildNumber,
           }));
 
@@ -1529,10 +1419,10 @@ export const releaseReact = (command: cli.IReleaseReactCommand): Promise<void> =
         // For release-react, buildNumber is NOT auto-detected — it must be passed explicitly
         // via --buildNumber. Auto-detection only applies to release-native where the binary
         // build number is the natural targeting key.
-        const versionInfoPromise: Promise<ProjectVersionInfo> = (command.appStoreVersion && command.buildNumber)
+        const versionInfoPromise: Promise<ProjectVersionInfo> = command.appStoreVersion
           ? Q({ appVersion: command.appStoreVersion, buildNumber: command.buildNumber })
           : getReactNativeProjectVersionInfo(command, projectName).then((detected) => ({
-              appVersion: command.appStoreVersion || detected.appVersion,
+              appVersion: detected.appVersion,
               buildNumber: command.buildNumber,
             }));
 

--- a/script/utils/gradle-utils.ts
+++ b/script/utils/gradle-utils.ts
@@ -1,0 +1,164 @@
+// Detects the Android versionName/versionCode a CodePush release should target.
+// Groovy DSL (build.gradle) is parsed statically; Kotlin DSL (build.gradle.kts) may
+// compute values from arbitrary expressions, so it is evaluated by running the
+// project's Gradle wrapper with an injected task that prints the resolved values.
+
+import * as childProcess from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { promisify } from "util";
+import * as chalk from "chalk";
+
+import { fileExists } from "./file-utils";
+import { isValidVersion } from "../react-native-utils";
+
+const g2js = require("gradle-to-js/lib/parser");
+const properties = require("properties");
+
+const exec = promisify(childProcess.exec);
+
+export interface AndroidVersionInfo {
+  appVersion?: string;
+  buildNumber?: string;
+}
+
+/** Raw values from the build script — literals or references to Gradle properties. */
+interface GradleVersionFields {
+  versionName: string | null;
+  versionCode: string | number | null;
+}
+
+const FALLBACK_HINT = "Pass the version explicitly with --targetBinaryVersion to skip Gradle detection.";
+
+// "revopush"-prefixed to avoid collisions with project tasks; written in Groovy,
+// which Gradle accepts as an init script for projects of either DSL.
+const PRINT_VERSION_TASK = "_revopushPrintVersion";
+const printVersionInitScript = (moduleName: string) => `
+allprojects {
+  afterEvaluate { proj ->
+    if (proj.name == '${moduleName}') {
+      task ${PRINT_VERSION_TASK} {
+        doLast {
+          def android = proj.extensions.findByName('android')
+          if (android == null) {
+            throw new GradleException("Project ':${moduleName}' does not apply the Android Gradle plugin (no 'android' extension found).")
+          }
+          println groovy.json.JsonOutput.toJson([
+            versionName: android.defaultConfig.versionName,
+            versionCode: android.defaultConfig.versionCode?.toString()
+          ])
+        }
+      }
+    }
+  }
+}
+`.trim();
+
+/** @param gradleFile build script path or its directory; defaults to "android/app". */
+export async function getAndroidVersionInfo(gradleFile?: string | null): Promise<AndroidVersionInfo> {
+  const buildFile = resolveGradleBuildFile(gradleFile ?? path.join("android", "app"));
+  const { versionName, versionCode } = buildFile.endsWith(".kts")
+    ? await evaluateKotlinDslBuildFile(buildFile)
+    : await parseGroovyDslBuildFile(buildFile);
+
+  const appVersion = resolveAppVersion(versionName, buildFile);
+  const buildNumber = resolveBuildNumber(versionCode);
+  if (!buildNumber) {
+    console.log(chalk.yellow(
+      `Warning: Unable to read "android.defaultConfig.versionCode" from "${buildFile}". ` +
+      `This is expected if it is set dynamically (e.g. on CI). Pass --buildNumber explicitly to include it in the release.`
+    ));
+  }
+  return { appVersion, buildNumber };
+}
+
+/** Locates the build script: the given file itself, or inside the given directory (Kotlin DSL preferred). */
+function resolveGradleBuildFile(gradleFile: string): string {
+  const candidates = [gradleFile, path.join(gradleFile, "build.gradle.kts"), path.join(gradleFile, "build.gradle")];
+  const buildFile = candidates.find(fileExists);
+  if (!buildFile) {
+    throw new Error(`Unable to find gradle file "${gradleFile}".`);
+  }
+  return buildFile;
+}
+
+async function parseGroovyDslBuildFile(buildFile: string): Promise<GradleVersionFields> {
+  const parsed: any = await g2js.parseFile(buildFile).catch(() => {
+    throw new Error(`Unable to parse the "${buildFile}" file. Please ensure it is a well-formed Gradle file.`);
+  });
+  // g2js yields an array when the file contains multiple 'android' blocks.
+  const androidBlocks: any[] = Array.isArray(parsed.android) ? parsed.android : [parsed.android];
+  const defaultConfig = androidBlocks.find((block) => block?.defaultConfig)?.defaultConfig;
+  if (!defaultConfig && /^\s*val\s+/m.test(fs.readFileSync(buildFile, "utf8"))) {
+    throw new Error(
+      `"${buildFile}" appears to contain Kotlin DSL syntax. Gradle determines the script language by file extension — ` +
+      `rename the file to "${path.basename(buildFile)}.kts" to make it a valid Kotlin DSL build script.`
+    );
+  }
+  return {
+    // g2js keeps the Groovy quotes around string literals — strip them.
+    versionName: defaultConfig?.versionName?.replace(/"/g, "").trim() ?? null,
+    versionCode: defaultConfig?.versionCode ?? null,
+  };
+}
+
+async function evaluateKotlinDslBuildFile(buildFile: string): Promise<GradleVersionFields> {
+  // The build file lives in the application module folder (typically android/app);
+  // its parent is the Gradle project root, and the folder name is the module name.
+  const moduleName = path.basename(path.dirname(path.resolve(buildFile)));
+  const androidDir = path.resolve(buildFile, "..", "..");
+  const gradlew = path.join(androidDir, process.platform === "win32" ? "gradlew.bat" : "gradlew");
+  if (!fileExists(gradlew)) {
+    throw new Error(`No Gradle wrapper found at "${gradlew}", required to evaluate "${buildFile}". ${FALLBACK_HINT}`);
+  }
+
+  const initScript = path.join(os.tmpdir(), `revopush-init-${process.pid}.gradle`);
+
+  fs.writeFileSync(initScript, printVersionInitScript(moduleName), "utf8");
+  try {
+    const { stdout } = await exec(
+      `"${gradlew}" --project-dir "${androidDir}" --init-script "${initScript}" -q :${moduleName}:${PRINT_VERSION_TASK}`,
+      { timeout: 120000 }
+    );
+    // The task's JSON is the last line; configuration-phase output (plugin notices, printlns) may precede it.
+    return JSON.parse(stdout.trim().split(/\r?\n/).pop() ?? "");
+  } catch (error) {
+    throw new Error(`Gradle failed while reading the version from "${buildFile}": ${error.message}\n${FALLBACK_HINT}`);
+  } finally {
+    fs.rmSync(initScript, { force: true });
+  }
+}
+
+function resolveAppVersion(versionName: string | null, buildFile: string): string | undefined {
+  if (!versionName) return undefined;
+
+  // A value that isn't valid semver and doesn't start with a digit is a property reference.
+  const isPropertyRef = !isValidVersion(versionName) && !/^\d/.test(versionName);
+  const appVersion = isPropertyRef ? lookupGradleProperty(versionName.replace("project.", "")) : versionName;
+
+  if (!appVersion || !isValidVersion(appVersion)) {
+    throw new Error(
+      `Unable to resolve a valid semver app version (e.g. 1.3.2) from "android.defaultConfig.versionName" in "${buildFile}" ` +
+      `(found: "${versionName}"). ${FALLBACK_HINT}`
+    );
+  }
+  return appVersion;
+}
+
+function resolveBuildNumber(versionCode: string | number | null): string | undefined {
+  const text = versionCode?.toString();
+  if (!text) return undefined;
+  // A non-numeric value is a reference to a Gradle property (e.g. "project.versionCode").
+  return (/^\d+$/.test(text) ? text : lookupGradleProperty(text.replace("project.", ""))) || undefined;
+}
+
+function lookupGradleProperty(key: string): string | undefined {
+  const files = [path.join("android", "app", "gradle.properties"), path.join("android", "gradle.properties")];
+  for (const file of files) {
+    if (!fileExists(file)) continue;
+    // The properties parser type-converts values (e.g. "2" becomes a number) — normalize back to string.
+    const value = properties.parse(fs.readFileSync(file, "utf8"))?.[key]?.toString();
+    if (value) return value;
+  }
+}


### PR DESCRIPTION
 Problem

  Newer React Native projects use Kotlin DSL (build.gradle.kts) for Android builds. The CLI detected --targetBinaryVersion by statically parsing android/app/build.gradle with gradle-to-js,
  which only understands Groovy DSL — for Kotlin DSL projects, version auto-detection failed entirely and releases required manually passing --targetBinaryVersion.

  Solution

  Version detection now picks a strategy based on the build file flavor:

  - Groovy DSL (build.gradle) — parsed statically with gradle-to-js, exactly as before. No behavior change for existing projects.
  - Kotlin DSL (build.gradle.kts) — a .kts script can compute versionName/versionCode from arbitrary expressions (env vars, gradle.properties references, helper functions), so static parsing is
  unreliable. Instead, the CLI runs the project's own Gradle wrapper with a temporary injected init script that registers a _revopushPrintVersion task, which prints the fully-resolved values
  as JSON. This returns exactly what the real build would use. Requires gradlew + Java; if missing, the CLI fails with an actionable message suggesting --targetBinaryVersion.

  All Android version-detection logic moved from command-executor.ts into a new focused module, script/utils/gradle-utils.ts, with a single public entry point
  getAndroidVersionInfo(gradleFile?).

  Changes

  - New: script/utils/gradle-utils.ts — build-file resolution (.kts preferred when both exist), Groovy static parse, Kotlin DSL evaluation via Gradle subprocess, gradle.properties reference
  resolution, semver validation.
  - script/command-executor.ts — the ~115-line Android branch in getReactNativeProjectVersionInfo replaced with one call to getAndroidVersionInfo; removed now-unused gradle-to-js/properties
  requires.
  - Lazy detection — release-react and release-expo now skip version detection entirely when --targetBinaryVersion is provided (previously both --targetBinaryVersion and --buildNumber were
  required to skip). No point running Gradle when the user already supplied the version.

  Robustness details

  - App module name derived from the build file's parent directory (not hardcoded to app), so custom --gradleFile layouts work
  - Task output parsed from the last stdout line only — immune to configuration-phase output from plugins (autolinking notices, apply from: scripts)
  - The init task verifies the Android Gradle Plugin is applied and throws a clear GradleException otherwise
  - Misnamed files detected: Kotlin syntax inside a build.gradle (which Gradle itself rejects) produces an error suggesting the .kts rename instead of a confusing "unable to read versionCode"
  warning
  - Windows: uses gradlew.bat; temp init script cleanup in finally; 2-minute Gradle timeout
  - --gradleFile may arrive as null from yargs — handled explicitly