### PR TITLE
unzipper.Extract for IPA files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revopush/code-push-cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revopush/code-push-cli",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "@devicefarmer/adbkit-apkreader": "^3.2.4",
         "aab-parser": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revopush/code-push-cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Management CLI for the CodePush service",
   "main": "./script/cli.js",
   "scripts": {

--- a/script/utils/file-utils.ts
+++ b/script/utils/file-utils.ts
@@ -69,10 +69,7 @@ export async function downloadBlob(url: string, folder: string, filename: string
 }
 
 export async function extractIPA(zipPath: string, extractTo: string) {
-  const extractStream = unzipper.Extract({ path: extractTo });
-  await new Promise<void>((resolve, reject) => {
-    fs.createReadStream(zipPath).pipe(extractStream).on("close", resolve).on("error", reject);
-  });
+  await fs.createReadStream(zipPath).pipe(unzipper.Extract({ path: extractTo })).promise();
 }
 
 export async function extractAPK(zipPath: string, extractTo: string) {


### PR DESCRIPTION
The bug: unzipper.Extract is a transform stream that internally spawns individual file-write streams for each zip entry. When you listen for close on the extractStream, that event fires when
  the transform stream itself closes — but the individual file writers it spawned may still be flushing to disk. The Promise resolves before all files are written, so fast-completing archives
  may miss entries at the end (like Info.plist).

  Compare with downloadBlob just above it — that one correctly listens for finish on the write stream, not close.

  The fix: unzipper exposes a .promise() method on its Extract stream that resolves only after all entries are fully written:

```
  export async function extractIPA(zipPath: string, extractTo: string) {
    await fs.createReadStream(zipPath).pipe(unzipper.Extract({ path: extractTo })).promise();
  }
```
