### PR TITLE
0.0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revopush/code-push-cli",
-  "version": "0.0.13",
+  "version": "0.0.14-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revopush/code-push-cli",
-      "version": "0.0.13",
+      "version": "0.0.14-rc.1",
       "dependencies": {
         "@devicefarmer/adbkit-apkreader": "^3.2.4",
         "aab-parser": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revopush/code-push-cli",
-  "version": "0.0.13",
+  "version": "0.0.14-rc.1",
   "description": "Management CLI for the CodePush service",
   "main": "./script/cli.js",
   "scripts": {

--- a/script/binary-utils.ts
+++ b/script/binary-utils.ts
@@ -1,11 +1,12 @@
 import * as path from "path";
 import * as fs from "fs";
+import * as crypto from "crypto";
 import * as chalk from "chalk";
 import { log } from "./command-executor";
-import { hashFile } from "./hash-utils";
 import * as os from "os";
 import * as Q from "q";
 import * as yazl from "yazl";
+import * as unzipper from "unzipper";
 import { readFile } from "node:fs/promises";
 import * as plist from "plist"
 import * as bplist from "bplist-parser";
@@ -49,46 +50,43 @@ export async function extractMetadataFromAndroid(extractFolder, outputFolder) {
   return zipPath;
 }
 
-export async function extractMetadataFromIOS(extractFolder, outputFolder) {
-  const payloadFolder = path.join(extractFolder, "Payload");
-  if (!fs.existsSync(payloadFolder)) {
-    throw new Error("Invalid IPA structure: Payload folder not found.");
-  }
+export async function extractMetadataFromIOS(ipaPath: string, outputFolder: string) {
+  const { files, appPrefix } = await openIPA(ipaPath);
 
-  const appFolders = fs.readdirSync(payloadFolder).filter((item) => {
-    const itemPath = path.join(payloadFolder, item);
-    return fs.statSync(itemPath).isDirectory() && item.endsWith(".app");
-  });
-
-  if (appFolders.length === 0) {
-    throw new Error("Invalid IPA structure: No .app folder found in Payload.");
-  }
-
-  const appFolder = path.join(payloadFolder, appFolders[0]);
-  const codePushFolder = path.join(appFolder, "assets");
+  const assetsPrefix = `${appPrefix}assets/`;
+  const bundlePath = `${appPrefix}main.jsbundle`;
 
   const fileHashes: { [key: string]: string } = {};
+  let bundleBuffer: Buffer | null = null;
 
-  if (fs.existsSync(codePushFolder)) {
-    await calculateHashesForDirectory(codePushFolder, appFolder, fileHashes);
-  } else {
-    log(chalk.yellow(`\nWarning: CodePush folder not found in IPA.\n`));
+  for (const entry of files) {
+    if (entry.type !== "File") continue;
+
+    if (entry.path === bundlePath) {
+      bundleBuffer = await entry.buffer();
+    } else if (entry.path.startsWith(assetsPrefix)) {
+      const relativePath = entry.path.slice(appPrefix.length); // e.g. assets/img/logo.png
+      const hash = sha256(await entry.buffer());
+      fileHashes[`CodePush/${relativePath}`] = hash;
+      log(chalk.gray(`  ${relativePath}:${hash.substring(0, 8)}...\n`));
+    }
   }
 
-  const mainJsBundlePath = path.join(appFolder, "main.jsbundle");
-  if (fs.existsSync(mainJsBundlePath)) {
-    log(chalk.cyan(`\nFound main.jsbundle, calculating hash:\n`));
-    const bundleHash = await hashFile(mainJsBundlePath);
-    fileHashes["CodePush/main.jsbundle"] = bundleHash;
-
-    // Copy bundle to output folder
-    const outputCodePushFolder = path.join(outputFolder, "CodePush");
-    fs.mkdirSync(outputCodePushFolder, { recursive: true });
-    const outputBundlePath = path.join(outputCodePushFolder, "main.jsbundle");
-    fs.copyFileSync(mainJsBundlePath, outputBundlePath);
-  } else {
-    throw new Error("main.jsbundle not found in IPA root folder.");
+  if (Object.keys(fileHashes).length === 0) {
+    log(chalk.yellow(`\nWarning: CodePush assets folder not found in IPA.\n`));
   }
+
+  if (!bundleBuffer) {
+    throw new Error("main.jsbundle not found in IPA app folder.");
+  }
+
+  log(chalk.cyan(`\nFound main.jsbundle, calculating hash:\n`));
+  fileHashes["CodePush/main.jsbundle"] = sha256(bundleBuffer);
+
+  // Write bundle to output folder (needed for the release package zip)
+  const outputCodePushFolder = path.join(outputFolder, "CodePush");
+  fs.mkdirSync(outputCodePushFolder, { recursive: true });
+  fs.writeFileSync(path.join(outputCodePushFolder, "main.jsbundle"), bundleBuffer);
 
   // Save packageManifest.json
   const manifestPath = path.join(outputFolder, "packageManifest.json");
@@ -102,28 +100,28 @@ export async function extractMetadataFromIOS(extractFolder, outputFolder) {
   return zipPath;
 }
 
-async function calculateHashesForDirectory(
-  directoryPath: string,
-  basePath: string,
-  fileHashes: { [key: string]: string }
-) {
-  const items = fs.readdirSync(directoryPath);
+function sha256(buffer: Buffer): string {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
 
-  for (const item of items) {
-    const itemPath = path.join(directoryPath, item);
-    const stat = fs.statSync(itemPath);
+// Open the IPA via its central directory (the authoritative entry index) instead of
+// streaming extraction, which is known to silently drop files. The count check guards
+// against a truncated/corrupt archive.
+async function openIPA(ipaPath: string): Promise<{ files: any[]; appPrefix: string }> {
+  const directory = await unzipper.Open.file(ipaPath);
 
-    if (stat.isDirectory()) {
-      await calculateHashesForDirectory(itemPath, basePath, fileHashes);
-    } else {
-      // Calculate relative path from basePath (app folder) to the file
-      const relativePath = path.relative(basePath, itemPath).replace(/\\/g, "/");
-      const hash = await hashFile(itemPath);
-      const hashKey = `CodePush/${relativePath}`
-      fileHashes[hashKey] = hash;
-      log(chalk.gray(`  ${relativePath}:${hash.substring(0, 8)}...\n`));
-    }
+  if (directory.files.length !== directory.numberOfRecords) {
+    throw new Error(
+      `Invalid IPA: central directory lists ${directory.numberOfRecords} entries but ${directory.files.length} were read. The file may be corrupt or truncated.`
+    );
   }
+
+  const appMatch = directory.files.map((f) => f.path.match(/^(Payload\/[^/]+\.app)\//)).find(Boolean);
+  if (!appMatch) {
+    throw new Error('Invalid IPA structure: no "Payload/*.app" folder found.');
+  }
+
+  return { files: directory.files, appPrefix: `${appMatch[1]}/` };
 }
 
 
@@ -164,46 +162,30 @@ function createZipArchive(sourceFolder: string, zipPath: string, filesToInclude:
   });
 }
 
-function parseAnyPlistFile(plistPath: string): any {
-  const buf = fs.readFileSync(plistPath);
-
+function parsePlistBuffer(buf: Buffer): any {
   if (buf.slice(0, 6).toString("ascii") === "bplist") {
     const arr = bplist.parseBuffer(buf);
     if (!arr?.length) throw new Error("Empty binary plist");
     return arr[0];
   }
 
-  const xml = buf.toString("utf8");
-  return plist.parse(xml);
+  return plist.parse(buf.toString("utf8"));
 }
 
-export async function getIosVersion(extractFolder: string) {
-  const payloadFolder = path.join(extractFolder, "Payload");
-  if (!fs.existsSync(payloadFolder)) {
-    throw new Error("Invalid IPA structure: Payload folder not found.");
+export async function getIosVersion(ipaPath: string) {
+  const { files, appPrefix } = await openIPA(ipaPath);
+
+  const plistEntry = files.find((f) => f.path === `${appPrefix}Info.plist`);
+  if (!plistEntry) {
+    throw new Error("Info.plist not found in IPA app folder.");
   }
 
-  const appFolders = fs.readdirSync(payloadFolder).filter((item) => {
-    const itemPath = path.join(payloadFolder, item);
-    return fs.statSync(itemPath).isDirectory() && item.endsWith(".app");
-  });
+  const data = parsePlistBuffer(await plistEntry.buffer());
 
-  if (appFolders.length === 0) {
-    throw new Error("Invalid IPA structure: No .app folder found in Payload.");
-  }
-
-  const appFolder = path.join(payloadFolder, appFolders[0]);
-
-  const plistPath = path.join(appFolder, "Info.plist");
-
-  const data = parseAnyPlistFile(plistPath);
-
-  console.log('App Version (Short):', data.CFBundleShortVersionString);
-  console.log('Build Number:', data.CFBundleVersion);
-  console.log('Bundle ID:', data.CFBundleIdentifier);
+  log(chalk.cyan(`App Version: ${data.CFBundleShortVersionString}, Build: ${data.CFBundleVersion}\n`));
 
   return {
     version: data.CFBundleShortVersionString,
-    build: data.CFBundleVersion
+    build: data.CFBundleVersion,
   };
 }

--- a/script/command-executor.ts
+++ b/script/command-executor.ts
@@ -40,7 +40,7 @@ import {
   runHermesEmitBinaryCommand,
   takeHermesBaseBytecode,
 } from "./react-native-utils";
-import { fileDoesNotExistOrIsDirectory, fileExists, isBinaryOrZip, extractIPA, extractAPK, extractAAB } from "./utils/file-utils";
+import { fileDoesNotExistOrIsDirectory, fileExists, isBinaryOrZip, extractAPK, extractAAB } from "./utils/file-utils";
 import { getAndroidVersionInfo } from "./utils/gradle-utils";
 
 import AccountManager = require("./management-sdk");
@@ -1539,10 +1539,9 @@ export const releaseNative = (command: cli.IReleaseNativeCommand): Promise<void>
         let releaseCommandPartial: Partial<cli.IReleaseReactCommand>;
 
         if (platform === "ios") {
-          log(chalk.cyan(`\nExtracting IPA file:\n`));
-          await extractIPA(targetBinaryPath, extractFolder);
-          const metadataZip = await extractMetadataFromIOS(extractFolder, outputFolder);
-          const buildVersion = await getIosVersion(extractFolder);
+          log(chalk.cyan(`\nReading IPA file:\n`));
+          const metadataZip = await extractMetadataFromIOS(targetBinaryPath, outputFolder);
+          const buildVersion = await getIosVersion(targetBinaryPath);
           releaseCommandPartial = {
             package: metadataZip,
             appStoreVersion: buildVersion?.version,

--- a/script/command-executor.ts
+++ b/script/command-executor.ts
@@ -1205,69 +1205,93 @@ export const runExpoExportEmbedCommand = async (
   });
 };
 
+const REQUIRED_OUTPUT_DIR_NAME = "CodePush";
+
+interface ReactReleaseInputs {
+  platform: string;
+  bundleName: string;
+  entryFile: string;
+  projectName: string;
+}
+
+// Up-front validation for the React-style release flows (release-react / release-expo).
+// Throws on the first violation and returns the derived inputs. The semver-range check
+// lives in the chain since it needs the resolved app version.
+function validateReactReleaseCommand(
+  command: cli.IReleaseReactCommand,
+  options: { resolveEntryFile: boolean }
+): ReactReleaseInputs {
+  const { resolveEntryFile } = options;
+  const platform: string = (command.platform = command.platform.toLowerCase());
+
+  // Only android and ios are supported.
+  if (platform !== "android" && platform !== "ios") {
+    throw new Error('Platform must be either "android" or "ios".');
+  }
+
+  // Diff updates require the package to live under a "CodePush" folder.
+  if (command.outputDir && path.basename(command.outputDir) !== REQUIRED_OUTPUT_DIR_NAME) {
+    throw new Error(
+      `The "--outputDir" path must end with a folder named "${REQUIRED_OUTPUT_DIR_NAME}" ` +
+        `(e.g. "./build/${REQUIRED_OUTPUT_DIR_NAME}"). Received: "${command.outputDir}".`
+    );
+  }
+
+  // The command must run inside a React Native project.
+  let projectPackageJson: any;
+  try {
+    projectPackageJson = require(path.join(process.cwd(), "package.json"));
+  } catch (error) {
+    throw new Error('Unable to find or read "package.json" in the CWD. The command must be executed in a React Native project folder.');
+  }
+
+  const projectName: string = projectPackageJson.name;
+  if (!projectName) {
+    throw new Error('The "package.json" file in the CWD does not have the "name" field set.');
+  }
+  if (!projectPackageJson.dependencies?.["react-native"]) {
+    throw new Error("The project in the CWD is not a React Native project.");
+  }
+
+  // Resolve and validate the JS entry file (only flows that bundle locally need it).
+  let entryFile: string = command.entryFile;
+  if (resolveEntryFile) {
+    if (!entryFile) {
+      entryFile = `index.${platform}.js`;
+      if (fileDoesNotExistOrIsDirectory(entryFile)) {
+        entryFile = "index.js";
+      }
+      if (fileDoesNotExistOrIsDirectory(entryFile)) {
+        throw new Error(`Entry file "index.${platform}.js" or "index.js" does not exist.`);
+      }
+    } else if (fileDoesNotExistOrIsDirectory(entryFile)) {
+      throw new Error(`Entry file "${entryFile}" does not exist.`);
+    }
+  }
+
+  // Default the bundle name from the platform when the user did not pass one.
+  const bundleName: string = command.bundleName || (platform === "ios" ? "main.jsbundle" : `index.${platform}.bundle`);
+
+  return { platform, bundleName, entryFile, projectName };
+}
+
 export const releaseExpo = (command: cli.IReleaseReactCommand): Promise<void> => {
-  let bundleName: string = command.bundleName;
-  // let entryFile: string = command.entryFile;
+  const { platform, bundleName, projectName } = validateReactReleaseCommand(command, {
+    resolveEntryFile: false,
+  });
+
   const outputFolder: string = command.outputDir || path.join(os.tmpdir(), "CodePush");
   const sourcemapOutputFolder: string = command.sourcemapOutput || path.join(os.tmpdir(), "CodePushSourceMap");
   const baseReleaseTmpFolder: string = path.join(os.tmpdir(), "CodePushBaseRelease");
-  const platform: string = (command.platform = command.platform.toLowerCase());
+
   const releaseCommand: cli.IReleaseReactCommand = <any>command;
+  releaseCommand.package = outputFolder;
+  releaseCommand.outputDir = outputFolder;
+  releaseCommand.bundleName = bundleName;
 
   return sdk
     .getDeployment(command.appName, command.deploymentName)
     .then(async () => {
-      switch (platform) {
-        case "android":
-        case "ios":
-          if (!bundleName) {
-            bundleName = platform === "ios" ? "main.jsbundle" : `index.${platform}.bundle`;
-          }
-          break;
-
-        default:
-          throw new Error('Platform must be either "android" or "ios" for the "release-expo" command.');
-      }
-
-      releaseCommand.package = outputFolder;
-      releaseCommand.outputDir = outputFolder;
-      releaseCommand.bundleName = bundleName;
-
-      let projectName: string;
-
-      try {
-        const projectPackageJson: any = require(path.join(process.cwd(), "package.json"));
-        projectName = projectPackageJson.name;
-        if (!projectName) {
-          throw new Error('The "package.json" file in the CWD does not have the "name" field set.');
-        }
-
-        if (!projectPackageJson.dependencies["react-native"]) {
-          throw new Error("The project in the CWD is not a React Native project.");
-        }
-      } catch (error) {
-        throw new Error(
-          'Unable to find or read "package.json" in the CWD. The "release-expo" command must be executed in a React Native project folder.'
-        );
-      }
-
-      // TODO: do we really need entryFile for expo?
-
-      // if (!entryFile) {
-      //   entryFile = `index.${platform}.js`;
-      //   if (fileDoesNotExistOrIsDirectory(entryFile)) {
-      //     entryFile = "index.js";
-      //   }
-      //
-      //   if (fileDoesNotExistOrIsDirectory(entryFile)) {
-      //     throw new Error(`Entry file "index.${platform}.js" or "index.js" does not exist.`);
-      //   }
-      // } else {
-      //   if (fileDoesNotExistOrIsDirectory(entryFile)) {
-      //     throw new Error(`Entry file "${entryFile}" does not exist.`);
-      //   }
-      // }
-
       // For release-expo, buildNumber is NOT auto-detected — it must be passed explicitly
       // via --buildNumber. Auto-detection only applies to release-native where the binary
       // build number is the natural targeting key.
@@ -1352,70 +1376,25 @@ export const releaseExpo = (command: cli.IReleaseReactCommand): Promise<void> =>
 };
 
 export const releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => {
-  let bundleName: string = command.bundleName;
-  let entryFile: string = command.entryFile;
+  const { platform, bundleName, entryFile, projectName } = validateReactReleaseCommand(command, {
+    resolveEntryFile: true,
+  });
+
   const outputFolder: string = command.outputDir || path.join(os.tmpdir(), "CodePush");
   const sourcemapOutputFolder: string = command.sourcemapOutput || path.join(os.tmpdir(), "CodePushSourceMap");
   const baseReleaseTmpFolder: string = path.join(os.tmpdir(), "CodePushBaseRelease");
-  const platform: string = (command.platform = command.platform.toLowerCase());
+
   const releaseCommand: cli.IReleaseReactCommand = <any>command;
-  // Check for app and deployment exist before releasing an update.
+  releaseCommand.package = outputFolder;
+  releaseCommand.outputDir = outputFolder;
+  releaseCommand.bundleName = bundleName;
+
+  // Check that the app and deployment exist before releasing an update.
   // This validation helps to save about 1 minute or more in case user has typed wrong app or deployment name.
   return (
     sdk
       .getDeployment(command.appName, command.deploymentName)
       .then(async () => {
-        switch (platform) {
-          case "android":
-          case "ios":
-          case "windows":
-            if (!bundleName) {
-              bundleName = platform === "ios" ? "main.jsbundle" : `index.${platform}.bundle`;
-            }
-
-            break;
-          default:
-            throw new Error('Platform must be either "android", "ios" or "windows".');
-        }
-
-        releaseCommand.package = outputFolder;
-        releaseCommand.outputDir = outputFolder;
-        releaseCommand.bundleName = bundleName;
-
-        let projectName: string;
-
-        try {
-          const projectPackageJson: any = require(path.join(process.cwd(), "package.json"));
-          projectName = projectPackageJson.name;
-          if (!projectName) {
-            throw new Error('The "package.json" file in the CWD does not have the "name" field set.');
-          }
-
-          if (!projectPackageJson.dependencies["react-native"]) {
-            throw new Error("The project in the CWD is not a React Native project.");
-          }
-        } catch (error) {
-          throw new Error(
-            'Unable to find or read "package.json" in the CWD. The "release-react" command must be executed in a React Native project folder.'
-          );
-        }
-
-        // TODO: check entry file detection
-        if (!entryFile) {
-          entryFile = `index.${platform}.js`;
-          if (fileDoesNotExistOrIsDirectory(entryFile)) {
-            entryFile = "index.js";
-          }
-
-          if (fileDoesNotExistOrIsDirectory(entryFile)) {
-            throw new Error(`Entry file "index.${platform}.js" or "index.js" does not exist.`);
-          }
-        } else {
-          if (fileDoesNotExistOrIsDirectory(entryFile)) {
-            throw new Error(`Entry file "${entryFile}" does not exist.`);
-          }
-        }
-
         // For release-react, buildNumber is NOT auto-detected — it must be passed explicitly
         // via --buildNumber. Auto-detection only applies to release-native where the binary
         // build number is the natural targeting key.

--- a/script/command-parser.ts
+++ b/script/command-parser.ts
@@ -700,16 +700,12 @@ yargs
         "release-react MyApp android -d Production",
         'Releases the React Native Android project in the current working directory to the "MyApp" app\'s "Production" deployment'
       )
-      .example(
-        "release-react MyApp windows --dev",
-        'Releases the development bundle of the React Native Windows project in the current working directory to the "MyApp" app\'s "Staging" deployment'
-      )
       .option("bundleName", {
         alias: "b",
         default: null,
         demand: false,
         description:
-          'Name of the generated JS bundle file. If unspecified, the standard bundle name will be used, depending on the specified platform: "main.jsbundle" (iOS), "index.android.bundle" (Android) or "index.windows.bundle" (Windows)',
+          'Name of the generated JS bundle file. If unspecified, the standard bundle name will be used, depending on the specified platform: "main.jsbundle" (iOS) or "index.android.bundle" (Android)',
         type: "string",
       })
       .option("deploymentName", {
@@ -807,7 +803,7 @@ yargs
         default: null,
         demand: false,
         description:
-          'Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the "Info.plist" (iOS), "build.gradle" (Android) or "Package.appxmanifest" (Windows) files.',
+          'Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the "Info.plist" (iOS) or "build.gradle" (Android) files.',
         type: "string",
       })
       .option("outputDir", {
@@ -909,7 +905,7 @@ yargs
         default: null,
         demand: false,
         description:
-          'Name of the generated JS bundle file. If unspecified, the standard bundle name will be used, depending on the specified platform: "main.jsbundle" (iOS), "index.android.bundle" (Android) or "index.windows.bundle" (Windows)',
+          'Name of the generated JS bundle file. If unspecified, the standard bundle name will be used, depending on the specified platform: "main.jsbundle" (iOS) or "index.android.bundle" (Android)',
         type: "string",
       })
       .option("deploymentName", {
@@ -1007,7 +1003,7 @@ yargs
         default: null,
         demand: false,
         description:
-          'Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the "Info.plist" (iOS), "build.gradle" (Android) or "Package.appxmanifest" (Windows) files.',
+          'Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the "Info.plist" (iOS) or "build.gradle" (Android) files.',
         type: "string",
       })
       .option("outputDir", {

--- a/script/react-native-utils.ts
+++ b/script/react-native-utils.ts
@@ -43,7 +43,7 @@ export async function getBundleSourceMapOutput(command: cli.IReleaseReactCommand
       break;
     }
     default:
-      throw new Error('Platform must be either "android", "ios" or "windows".');
+      throw new Error('Platform must be either "android" or "ios".');
   }
   return bundleSourceMapOutput;
 }
@@ -174,7 +174,7 @@ export async function runHermesEmitBinaryCommand(
             break;
           }
           default:
-            throw new Error('Platform must be either "android", "ios" or "windows".');
+            throw new Error('Platform must be either "android" or "ios".');
         }
       }
       const composeSourceMapsArgs = [
@@ -240,7 +240,7 @@ export async function getMinifyParams(command: cli.IReleaseReactCommand) {
       return isHermes ? ["--minify", false] : [];
     }
     default:
-      throw new Error('Platform must be either "android", "ios" or "windows".');
+      throw new Error('Platform must be either "android" or "ios".');
   }
 }
 


### PR DESCRIPTION
## Enforce `--outputDir` layout, drop Windows, and consolidate React-release validation

### Why
Diff updates require a release's uploaded package to live under a folder named **`CodePush`** — the base-bundle lookup (`react-native-utils.ts` `takeHermesBaseBytecode`) resolves the previous bundle via `path.basename(outputFolder)`, and binary extraction (`binary-utils.ts`) hardcodes a `CodePush/` prefix. When `--outputDir` is omitted we default to `os.tmpdir()/CodePush` (correct), but a **custom** `--outputDir` could be any name, silently breaking diff updates (the base bundle is never found, so no `-base-bytecode` diff is produced).

This PR fails the release early with a clear message when a custom `--outputDir` doesn't satisfy that requirement, removes Windows (no longer supported), and consolidates the scattered React-release validation into one place.

### What changed
**`--outputDir` validation**
- A custom `--outputDir` must end in a folder named `CodePush` (e.g. `./build/CodePush`); otherwise the release fails up front with:
  `The "--outputDir" path must end with a folder named "CodePush" (e.g. "./build/CodePush"). Received: "...".`
- Applies to `release-react` and `release-expo`. `release-native` is untouched (it nests `CodePush/` internally, so its basename is irrelevant).

**Drop Windows support**
- `release-react` now accepts only `android` / `ios`.
- Removed the Windows example and Windows mentions from `release-react` / `release-expo` help text in `command-parser.ts`.
- Updated the `'Platform must be either …'` messages in `react-native-utils.ts` to drop Windows. (OS-level Windows handling — Git Bash backslashes — is unchanged.)

**Consolidated validation (`command-executor.ts`)**
- Introduced a single `validateReactReleaseCommand(command, { resolveEntryFile })` that performs all up-front validation and returns the derived inputs (`platform`, `bundleName`, `entryFile`, `projectName`): platform check, `--outputDir` check, React Native project check, and entry-file resolution (skipped for Expo, whose `expo export:embed` resolves its own entry point). The semver-range check stays in the chain since it needs the async-resolved app version.
- `releaseReact` / `releaseExpo` are now *validate → set up folders → run the chain*, removing the duplicated platform `switch`, `package.json` block, and entry-file logic from both.

**Bug fix / hardening (in the consolidation)**
- The old `try/catch` wrapped the field checks, so the specific *"name field not set"* / *"not a React Native project"* errors were swallowed and replaced by the generic *"unable to read package.json"*. The `try` now wraps only the `require`, so each error surfaces correctly.
- Guarded `dependencies?.["react-native"]` so a `package.json` with no `dependencies` reports *"not a React Native project"* instead of a misleading read error.

### Testing
- `npm run build` (tsc) passes; lint shows only pre-existing `no-unused-vars` warnings, none in touched code.
- `release-react MyApp ios --outputDir ./build/wrong` → fails immediately with the `CodePush` message.
- `--outputDir ./build/CodePush` (and trailing slash) → proceeds.
- Omitting `--outputDir` → still uses the temp `CodePush` folder.
- `release-react MyApp windows …` → rejected with `Platform must be either "android" or "ios".`
