### PR TITLE
Fix parse-duration, serialize-javascript, and uuid CVEs (REV-43)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "jszip": "^3.10.1",
         "moment": "^2.29.4",
         "opener": "^1.5.2",
-        "parse-duration": "1.1.0",
+        "parse-duration": "^2.1.6",
         "plist": "^3.1.0",
         "progress": "^2.0.3",
         "prompt": "^1.3.0",
@@ -65,6 +65,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.1.3",
         "which": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3834,9 +3837,9 @@
       }
     },
     "node_modules/parse-duration": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
-      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-2.1.6.tgz",
+      "integrity": "sha512-1/A2Exg3NcJGcYdgV/dn4frR7vO2hOW/ohQ4KIgbT4W3raVcpYSszPWiL6I6cKufi4jQM5NbGRXLBj8AoLM4iQ=="
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -4122,16 +4125,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -4427,13 +4420,12 @@
       "dev": true
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {
@@ -5092,11 +5084,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jszip": "^3.10.1",
     "moment": "^2.29.4",
     "opener": "^1.5.2",
-    "parse-duration": "1.1.0",
+    "parse-duration": "^2.1.6",
     "plist": "^3.1.0",
     "progress": "^2.0.3",
     "prompt": "^1.3.0",
@@ -56,6 +56,13 @@
     "xcode": "^3.0.1",
     "yargs": "^17.7.2",
     "yazl": "^2.5.1"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5",
+    "uuid": "^11.1.1"
+  },
+  "engines": {
+    "node": ">=20.19.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",

--- a/script/command-parser.ts
+++ b/script/command-parser.ts
@@ -1673,5 +1673,7 @@ function isDefined(object: any): boolean {
 }
 
 function parseDurationMilliseconds(durationString: string): number {
-  return Math.floor(parseDuration(durationString));
+  // parse-duration v2 is ESM: the parser is `.default`, and `?? 0` restores v1's
+  // handling of unparseable input (v2 returns null instead of 0).
+  return Math.floor(parseDuration.default(durationString) ?? 0);
 }


### PR DESCRIPTION
Clears three Dependabot advisories in the CLI. Independent of #37 (aab-parser/protobufjs).

## `parse-duration` — CVE-2025-25283 (HIGH, ReDoS)
Direct dep, bumped `1.1.0 → ^2.1.6`. Only used to parse an access-key `--ttl` string in `command-parser.ts`.
- v2 is **ESM-only**, so `require()` yields the namespace and the parser is `.default`.
- v2 returns `null` (v1 returned `NaN`) for unparseable input; `?? 0` preserves v1's `Math.floor(...) === 0` behavior.
- **Verified byte-identical to v1** across 18 TTL inputs (compound `1h30m`, decimals, empty, garbage, negatives).
- Adds `engines: node >=20.19.0`, required for `require(esm)`. Acceptable: Node 18 is EOL and RN toolchains already need Node 20+.

## `serialize-javascript` — GHSA-5c6j-r48x-rmvq (HIGH, RCE/DoS)
Transitive via `mocha` (**devDependency** → 6.0.2); never shipped to consumers. No 6.x patch exists, so pinned via `overrides` to `^7.0.5` (resolves 7.0.7).

## `uuid` — CVE-2026-41907 (MODERATE, ReDoS)
Transitive via `xcode@3.0.1 → uuid@7.0.3`. No fixed `xcode` release exists (npm's only suggestion is a downgrade), so pinned via `overrides` to `^11.1.1`.
- Verified compatible with xcode's `uuid.v4()` usage — `xcode.generateUuid()` still produces valid pbxproj IDs.
- **Caveat:** `xcode` is a runtime dep, so (like protobufjs in #37) this override cleans CI/this repo but doesn't reach published-CLI consumers until `xcode` ships a fix upstream. uuid is used only to *generate* v4 IDs here, not parse untrusted input, so the ReDoS isn't reachable in practice.

## Verification
- ✅ `tsc` clean; no new lint errors
- ✅ CLI boots (`--version` works → `require(esm)` OK at load)
- ✅ `xcode.generateUuid()` works under `uuid@11.1.1`
- ✅ `npm audit` clear for all three

## Note
The `uuid` alert was surfaced under the **`react-native-code-push-next`** repo — that repo needs its own separate fix.

Closes REV-43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)