### PR TITLE
Fix brace-expansion DoS advisories (REV-72)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,9 +1493,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3540,10 +3541,11 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }


### PR DESCRIPTION
Clears Dependabot alerts #62 and #63.

| Advisory | Issue | Patched in |
|---|---|---|
| [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | DoS via exponential-time expansion of consecutive non-expanding `{}` groups | 1.1.16 / 2.1.2 |
| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (CVE-2026-14257) | DoS via unbounded expansion length causing an OOM crash | 5.0.8, backported to 1.1.17 / 2.1.3 |

## Change

Both installed copies were stale relative to their own semver ranges, so `npm update brace-expansion` was sufficient — **lockfile-only**, no `overrides` entry and no manifest change:

| Path | Was | Now | Reachability |
|---|---|---|---|
| `rimraf@2 → glob@7 → minimatch@3` (also eslint) | 1.1.15 | **1.1.17** | production tree |
| `mocha@11 → minimatch@9` | 2.1.1 | **2.1.3** | dev only |

## Why not override to 5.0.8

brace-expansion 5.x exports a *named* `expand` (`exports.expand = expand`), while minimatch does `const expand = require('brace-expansion')`. Forcing 5.x would break glob/rimraf/eslint/mocha at runtime. The maintenance backports are the correct fix.

## Verification

Run against the actually-installed copies:

- Normal expansion unchanged — `a{b,c}d{1..3}` → `abd1,abd2,abd3,acd1,acd2,acd3` on both.
- GHSA-3jxr: 40 consecutive empty `{}` groups expand in 0 ms.
- GHSA-mh99: 6 chained 200 KB groups now cap at 3.6 M chars via the new `EXPANSION_MAX_LENGTH = 4_000_000` guard instead of growing unbounded.
- `tsc --noEmit` clean; eslint and mocha still resolve their globs.

## Known false positive after merge

`npm audit` and Dependabot will keep flagging GHSA-mh99-v99m-4gvg. That advisory currently declares one flat range `<= 5.0.7` with `first_patched_version: 5.0.8` and has not yet been amended for the 1.1.17 / 2.1.3 backports published 2026-07-28/29. The installed code is patched — confirmed by inspecting both tarballs and exercising the guard above.

Linear: [REV-72](https://linear.app/revopush/issue/REV-72/security-fix-brace-expansion-dos-advisories-in-cli-dependabot-62-63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)